### PR TITLE
Skip checking cell children length on verification

### DIFF
--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -148,9 +148,6 @@ func Verify(expr *ast.Value) error {
 		if len(expr.GetChildren()) != 1 {
 			return fmt.Errorf("Invalid number of arguments for %s!", expr.GetT().String())
 		}
-		if len(expr.GetChildren()[0].GetChildren()) < 5 {
-			return fmt.Errorf("Specified cell does not provide OutPoint!")
-		}
 	case ast.Value_GET_CODE_HASH:
 		fallthrough
 	case ast.Value_GET_HASH_TYPE:
@@ -196,9 +193,6 @@ func Verify(expr *ast.Value) error {
 	case ast.Value_GET_HEADER:
 		if len(expr.GetChildren()) != 1 {
 			return fmt.Errorf("Invalid number of arguments for %s!", expr.GetT().String())
-		}
-		if len(expr.GetChildren()[0].GetChildren()) < 6 {
-			return fmt.Errorf("Specified cell does not provide Header!")
 		}
 	case ast.Value_HASH:
 		if len(expr.GetChildren()) != 1 {

--- a/ruby/generic_services_pb.rb
+++ b/ruby/generic_services_pb.rb
@@ -14,8 +14,8 @@ module Generic
       self.unmarshal_class_method = :decode
       self.service_name = 'generic.GenericService'
 
-      rpc :Call, GenericParams, Ast::Value
-      rpc :Stream, GenericParams, stream(Ast::Value)
+      rpc :Call, ::Generic::GenericParams, ::Ast::Value
+      rpc :Stream, ::Generic::GenericParams, stream(::Ast::Value)
     end
 
     Stub = Service.rpc_stub_class


### PR DESCRIPTION
When the cell is to be filled by environment (for example if it's an
arg) it won't have any children.